### PR TITLE
overrides user agent stylesheet body margin prop

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,15 +13,16 @@
             font-weight: normal;
             font-style: normal;
         }
-        
+
         /* This part is needed to load the font in time for phaser */
         body {
             font-family: OpenSans;
+            margin: 0;
         }
         div {
             font-family: OpenSans;
         }
-        
+
     </style>
 </head>
 <body>
@@ -51,4 +52,4 @@
 	<script src="src/game.js"></script>
 </body>
 </html>
- 
+


### PR DESCRIPTION
The user agent stylesheet adds unnecessary margin to the body element. This fix overrides that, so the tool fits correctly in the unplatform ui's container.